### PR TITLE
#79 Change of the IG Id

### DIFF
--- a/ig.ini
+++ b/ig.ini
@@ -1,4 +1,4 @@
 [IG]
 template = hl7.at.fhir.template#current
-ig = fsh-generated/resources/ImplementationGuide-HL7ATCoreProfiles.json
+ig = fsh-generated/resources/ImplementationGuide-hl7.at.fhir.core.r4.json
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -10,7 +10,7 @@
 # │  supported properties, see:                                                                    │
 # │  http://build.fhir.org/ig/HL7/fhir-shorthand/branches/beta/sushi.html#ig-development           │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
-id: HL7ATCoreProfiles
+id: hl7.at.fhir.core.r4
 canonical: http://hl7.at/fhir/HL7ATCoreProfiles/4.0.1
 version: 1.1.0
 name: HL7AustriaImplementationGuide


### PR DESCRIPTION
Preparation for the FHIR Registry publication, same structure as for the R5 IG

Closes #79 