### PR TITLE
102 krankenanstaltennummer identifier is missing r4 hl7® at core organization profile

### DIFF
--- a/input/fsh/at-core-example-organization01.fsh
+++ b/input/fsh/at-core-example-organization01.fsh
@@ -18,6 +18,11 @@ Usage:       #example
 * identifier[VPNR].value = "123456789"
 * identifier[VPNR].system = "urn:oid:1.2.40.0.10.1.4.3.2"
 * identifier[VPNR].assigner.display = "Dachverband der österreichischen Sozialversicherungsträger"
+* identifier[KANR].value = "K101+"
+* identifier[KANR].system = "urn:oid:1.2.40.0.34.3.1.1"
+* identifier[KANR].assigner.display = "Österreichisches Bundesministerium für Gesundheit"
+
+
 
 * contact.telecom[0].use = 	http://hl7.org/fhir/contact-point-use#work
 * contact.telecom[0].system = http://hl7.org/fhir/contact-point-system#email

--- a/input/fsh/at-core-organization.fsh
+++ b/input/fsh/at-core-organization.fsh
@@ -21,7 +21,7 @@ Description:    "HL7® Austria FHIR® Core Profile for organization data in Aust
 * identifier ^slicing.discriminator.type = #value
 * identifier ^slicing.discriminator.path = "system"
 * identifier ^slicing.ordered = false
-* identifier contains GDA-OID 0..1 and VPNR 0..1 and VKZ 0..1
+* identifier contains GDA-OID 0..1 and VPNR 0..1 and VKZ 0..1 and KANR 0..1
 * identifier[GDA-OID].value 1..1
 * identifier[GDA-OID].value ^short = "OID for the GDA in Austria"
 * identifier[GDA-OID].system 1..1
@@ -38,5 +38,10 @@ Description:    "HL7® Austria FHIR® Core Profile for organization data in Aust
 * identifier[VKZ].system = "urn:oid:1.2.40.0.10.2.1.1.71" (exactly)
 * identifier[VKZ].system ^short = "OID for the Verwaltungskennzeichen (VKZ) in Austria"
 * identifier[VKZ].assigner.display = "Bundesministerium für Finanzen" (exactly)
-
+* identifier[KANR].value 1..1
+* identifier[KANR].value ^short = "Krankenanstaltennummer according to Krankenanstaltenkataster. Virtual KANRs are suffixed with '+' (e.g. 'K101+')"
+* identifier[KANR].system 1..1
+* identifier[KANR].system = "urn:oid:1.2.40.0.34.3.1.1" (exactly)
+* identifier[KANR].system ^short = "OID for the Austrian Federal Ministry of Health"
+* identifier[KANR].assigner.display = "Österreichisches Bundesministerium für Gesundheit" (exactly)
 * type from https://termgit.elga.gv.at/ValueSet/hl7-at-organizationtype (extensible)


### PR DESCRIPTION
I added slice for KANR and example data in HL7ATCoreOrganizationExample01. Only added a **virtual** Krankenanstaltennummer ("K101+") because the difference between virtual and normal is described in the short description of the slice.

Closes #102 